### PR TITLE
Fix: centralize TYPING_RULES and include in relevant system prompts

### DIFF
--- a/mm_agents/prompts.py
+++ b/mm_agents/prompts.py
@@ -1,9 +1,21 @@
+# Source of truth for typing rules
+TYPING_RULES = """
+# TYPING API RULES (MANDATORY)
+- To type text, you MUST use: pyautogui.write(<text>[, interval=...]).
+- Do NOT use: pyautogui.type()  (this function does not exist).
+- Prefer write() over typewrite(); if you must, pyautogui.typewrite(...) is acceptable but pyautogui.type(...) is forbidden.
+- For special keys use pyautogui.press('enter') / pyautogui.hotkey('ctrl','c') — never attempt to type special keys with write().
+- Never invent APIs. If unsure, default to pyautogui.write().
+""".strip()
+
 SYS_PROMPT_IN_SCREENSHOT_OUT_CODE = """
 You are an agent which follow my instruction and perform desktop computer tasks as instructed.
 You have good knowledge of computer and good internet connection and assume your code will run on a computer for controlling the mouse and keyboard.
 For each step, you will get an observation of an image, which is the screenshot of the computer screen and you will predict the action of the computer based on the image.
 
 You are required to use `pyautogui` to perform the action grounded to the observation, but DONOT use the `pyautogui.locateCenterOnScreen` function to locate the element you want to operate with since we have no image of the element you want to operate with. DONOT USE `pyautogui.screenshot()` to make screenshot.
+""".strip() + "\n" + TYPING_RULES + """
+
 Return one line or multiple lines of python code to perform the action each time, be time efficient. When predicting multiple lines of code, make some small sleep like `time.sleep(0.5);` interval so that the machine could take; Each time you need to predict a complete code, no variables or function can be shared from history
 You need to to specify the coordinates of by yourself based on your observation of current observation, but you should be careful to ensure that the coordinates are correct.
 You ONLY need to return the code inside a code block, like this:
@@ -25,6 +37,8 @@ You have good knowledge of computer and good internet connection and assume your
 For each step, you will get an observation of an image, which is the screenshot of the computer screen and the instruction and you will predict the next action to operate on the computer based on the image.
 
 You are required to use `pyautogui` to perform the action grounded to the observation, but DONOT use the `pyautogui.locateCenterOnScreen` function to locate the element you want to operate with since we have no image of the element you want to operate with. DONOT USE `pyautogui.screenshot()` to make screenshot.
+""".strip() + "\n" + TYPING_RULES + """
+
 Return one line or multiple lines of python code to perform the action each time, be time efficient. When predicting multiple lines of code, make some small sleep like `time.sleep(0.5);` interval so that the machine could take; Each time you need to predict a complete code, no variables or function can be shared from history
 You need to to specify the coordinates of by yourself based on your observation of current observation, but you should be careful to ensure that the coordinates are correct.
 You ONLY need to return the code inside a code block, like this:
@@ -539,6 +553,8 @@ You have good knowledge of computer and good internet connection and assume your
 For each step, you will get an observation of the desktop by accessibility tree, which is based on AT-SPI library. And you will predict the action of the computer based on the accessibility tree.
 
 You are required to use `pyautogui` to perform the action grounded to the observation, but DONOT use the `pyautogui.locateCenterOnScreen` function to locate the element you want to operate with since we have no image of the element you want to operate with. DONOT USE `pyautogui.screenshot()` to make screenshot.
+""".strip() + "\n" + TYPING_RULES + """
+
 Return one line or multiple lines of python code to perform the action each time, be time efficient. When predicting multiple lines of code, make some small sleep like `time.sleep(0.5);` interval so that the machine could take; Each time you need to predict a complete code, no variables or function can be shared from history
 You need to to specify the coordinates of by yourself based on your observation of current observation, but you should be careful to ensure that the coordinates are correct.
 You ONLY need to return the code inside a code block, like this:
@@ -806,6 +822,8 @@ For each step, you will get an observation of the desktop by 1) a screenshot; an
 And you will predict the action of the computer based on the screenshot and accessibility tree.
 
 You are required to use `pyautogui` to perform the action grounded to the observation, but DONOT use the `pyautogui.locateCenterOnScreen` function to locate the element you want to operate with since we have no image of the element you want to operate with. DONOT USE `pyautogui.screenshot()` to make screenshot.
+""".strip() + "\n" + TYPING_RULES + """
+
 Return one line or multiple lines of python code to perform the action each time, be time efficient. When predicting multiple lines of code, make some small sleep like `time.sleep(0.5);` interval so that the machine could take; Each time you need to predict a complete code, no variables or function can be shared from history
 You need to to specify the coordinates of by yourself based on your observation of current observation, but you should be careful to ensure that the coordinates are correct.
 You ONLY need to return the code inside a code block, like this:
@@ -1081,6 +1099,8 @@ pyautogui.dragTo(tag_1, button='left')
 ```
 When you think you can directly output precise x and y coordinates or there is no tag on which you want to interact, you can also use them directly. 
 But you should be careful to ensure that the coordinates are correct.
+""".strip() + "\n" + TYPING_RULES + """
+
 Return one line or multiple lines of python code to perform the action each time, be time efficient. When predicting multiple lines of code, make some small sleep like `time.sleep(0.5);` interval so that the machine could take; Each time you need to predict a complete code, no variables or function can be shared from history
 You need to to specify the coordinates of by yourself based on your observation of current observation, but you should be careful to ensure that the coordinates are correct.
 You ONLY need to return the code inside a code block, like this:
@@ -1131,6 +1151,8 @@ pyautogui.dragTo(tag_1, button='left')
 ```
 When you think you can directly output precise x and y coordinates or there is no tag on which you want to interact, you can also use them directly. 
 But you should be careful to ensure that the coordinates are correct.
+""".strip() + "\n" + TYPING_RULES + """
+
 Return one line or multiple lines of python code to perform the action each time, be time efficient. When predicting multiple lines of code, make some small sleep like `time.sleep(0.5);` interval so that the machine could take; Each time you need to predict a complete code, no variables or function can be shared from history
 You need to to specify the coordinates of by yourself based on your observation of current observation, but you should be careful to ensure that the coordinates are correct.
 You ONLY need to return the code inside a code block, like this:
@@ -1152,6 +1174,8 @@ You have good knowledge of computer and good internet connection and assume your
 For each step, you will get an observation of an image, which is the screenshot of the computer screen and you will predict the action of the computer based on the image.
 
 You are required to use `pyautogui` to perform the action grounded to the observation, but DONOT use the `pyautogui.locateCenterOnScreen` function to locate the element you want to operate with since we have no image of the element you want to operate with. DONOT USE `pyautogui.screenshot()` to make screenshot.
+""".strip() + "\n" + TYPING_RULES + """
+
 Return exactly ONE line of python code to perform the action each time. At each step, you MUST generate the corresponding instruction to the code before a # in a comment (example: # Click \"Yes, I trust the authors\" button\npyautogui.click(x=0, y=0, duration=1)\n)
 You need to to specify the coordinates of by yourself based on your observation of current observation, but you should be careful to ensure that the coordinates are correct.
 You ONLY need to return the code inside a code block, like this:
@@ -1173,7 +1197,7 @@ First give the current screenshot and previous things we did a short reflection,
 """.strip()
 
 AGUVIS_SYS_PROMPT = """You are a GUI agent. You are given a task and a screenshot of the screen. You need to perform a series of pyautogui actions to complete the task.
-"""
+""".strip() + "\n" + TYPING_RULES
 
 AGUVIS_PLANNING_PROMPT = """Please generate the next move according to the UI screenshot, instruction and previous actions.
 
@@ -1314,6 +1338,8 @@ Thought:
 Your thought should be returned in "Thought:" section. You MUST return the thought before the code.
 
 You are required to use `pyautogui` to perform the action grounded to the observation, but DONOT use the `pyautogui.locateCenterOnScreen` function to locate the element you want to operate with since we have no image of the element you want to operate with. DONOT USE `pyautogui.screenshot()` to make screenshot.
+""".strip() + "\n" + TYPING_RULES + """
+
 Return exactly ONE line of python code to perform the action each time. At each step, you MUST generate the corresponding instruction to the code before a # in a comment (example: # Click \"Yes, I trust the authors\" button\npyautogui.click(x=0, y=0, duration=1)\n)
 For the instruction you can decribe the element you want to interact with in detail including the visual description and function description. And make it clear and concise.
 For example you can describe what the element looks like, and what will be the expected result when you interact with it.
@@ -1546,6 +1572,8 @@ Thought:
 Your thought should be returned in "Thought:" section. You MUST return the thought before the code.
 
 You are required to use `pyautogui` to perform the action grounded to the observation, but DONOT use the `pyautogui.locateCenterOnScreen` function to locate the element you want to operate with since we have no image of the element you want to operate with. DONOT USE `pyautogui.screenshot()` to make screenshot.
+""".strip() + "\n" + TYPING_RULES + """
+
 Return exactly ONE line of python code to perform the action each time. At each step, you MUST generate the corresponding instruction to the code before a # in a comment (example: # Click \"Yes, I trust the authors\" button\npyautogui.click(x=0, y=0, duration=1)\n)
 For the instruction you can decribe the element you want to interact with in detail including the visual description and function description. And make it clear and concise.
 For example you can describe what the element looks like, and what will be the expected result when you interact with it.


### PR DESCRIPTION
Fix using of pyautogui.type() and other none missing attributes.
