### PR TITLE
feat: Add drag feature to ViewPort SFT tool

### DIFF
--- a/Turing_tooling/sft_utils/overlay_tool/viewport_window.py
+++ b/Turing_tooling/sft_utils/overlay_tool/viewport_window.py
@@ -114,6 +114,10 @@ class ViewPortWindow:
         # Picker popup state (None, "hotkey", "key", or "sleep")
         self.picker_active = None
         
+        # Drag mode state
+        self.drag_mode_active = False
+        self.drag_start_point: Optional[Tuple[int, int]] = None  # VM coordinates
+        
         # Create fullscreen window
         self.screen = pygame.display.set_mode((0, 0), pygame.FULLSCREEN)
         self.window_width = self.screen.get_width()
@@ -311,6 +315,16 @@ class ViewPortWindow:
             coord_surface = self.font.render(coord_text, True, self.CROSSHAIR)
             self.screen.blit(coord_surface, (135, 10))
         
+        # Drag mode indicator
+        if self.drag_mode_active:
+            mode_text = "🎯 DRAG MODE" if self.drag_start_point is None else "🎯 DRAG: Click end point"
+            mode_x = 260
+            mode_bg = pygame.Surface((180, 24), pygame.SRCALPHA)
+            mode_bg.fill((255, 180, 60, 150))  # Orange background
+            self.screen.blit(mode_bg, (mode_x, 8))
+            mode_surface = self.font.render(mode_text, True, self.BG_DARK)
+            self.screen.blit(mode_surface, (mode_x + 5, 10))
+        
         # Status message (center)
         center_x = self.window_width // 2
         if self.status_message:
@@ -366,10 +380,25 @@ class ViewPortWindow:
             
         mx, my = mouse_pos
         
+        # Choose crosshair color based on mode
+        if self.drag_mode_active:
+            crosshair_color = self.WARNING  # Orange for drag mode
+        else:
+            crosshair_color = self.CROSSHAIR  # Cyan for normal mode
+        
+        # If in drag mode and start point is set, draw a line from start to current position
+        if self.drag_mode_active and self.drag_start_point is not None:
+            start_screen_x, start_screen_y = self._vm_to_screen(self.drag_start_point[0], self.drag_start_point[1])
+            # Draw start point marker
+            pygame.draw.circle(self.screen, self.WARNING, (start_screen_x, start_screen_y), 8, 3)
+            pygame.draw.circle(self.screen, self.WARNING, (start_screen_x, start_screen_y), 3)
+            # Draw line from start to current
+            pygame.draw.line(self.screen, self.WARNING, (start_screen_x, start_screen_y), (mx, my), 2)
+        
         # Draw crosshair
-        pygame.draw.line(self.screen, self.CROSSHAIR, (mx - 15, my), (mx + 15, my), 2)
-        pygame.draw.line(self.screen, self.CROSSHAIR, (mx, my - 15), (mx, my + 15), 2)
-        pygame.draw.circle(self.screen, self.CROSSHAIR, (mx, my), 5, 2)
+        pygame.draw.line(self.screen, crosshair_color, (mx - 15, my), (mx + 15, my), 2)
+        pygame.draw.line(self.screen, crosshair_color, (mx, my - 15), (mx, my + 15), 2)
+        pygame.draw.circle(self.screen, crosshair_color, (mx, my), 5, 2)
     
     def _draw_minimap(self):
         """Draw minimap showing viewport position (only if viewport mode active)."""
@@ -406,7 +435,7 @@ class ViewPortWindow:
         
         # Panel dimensions - wider for better layout
         panel_w = 520
-        panel_h = 520
+        panel_h = 580  # Increased to accommodate drag button row
         panel_x = (self.window_width - panel_w) // 2
         panel_y = (self.window_height - panel_h) // 2
         
@@ -463,7 +492,7 @@ class ViewPortWindow:
                                "⏱️  Wait/Sleep", sleep_text, False, "sleep")
         y += row_height + 20
         
-        # === ACTION BUTTONS ROW ===
+        # === ACTION BUTTONS ROW 1 ===
         btn_w = 140
         btn_h = 38
         btn_gap = 15
@@ -472,6 +501,12 @@ class ViewPortWindow:
         self._draw_modern_button(btn_start_x, y, btn_w, btn_h, "↑ Scroll Up", "scroll_up")
         self._draw_modern_button(btn_start_x + btn_w + btn_gap, y, btn_w, btn_h, "↓ Scroll Down", "scroll_down")
         self._draw_modern_button(btn_start_x + (btn_w + btn_gap) * 2, y, btn_w, btn_h, "🔄 Refresh", "refresh")
+        y += btn_h + 12
+        
+        # === ACTION BUTTONS ROW 2 (Drag) ===
+        drag_btn_text = "🎯 Start Drag" if not self.drag_mode_active else "❌ Cancel Drag"
+        drag_btn_color = self.WARNING if self.drag_mode_active else self.ACCENT_DIM
+        self._draw_modern_button(btn_start_x, y, btn_w * 2 + btn_gap, btn_h, drag_btn_text, "drag", drag_btn_color)
         y += btn_h + 20
         
         # === FINISH BUTTON ===
@@ -665,7 +700,7 @@ class ViewPortWindow:
         
         # Panel dimensions (must match _draw_overlay)
         panel_w = 520
-        panel_h = 520
+        panel_h = 580  # Updated to match _draw_overlay (includes drag button row)
         panel_x = (self.window_width - panel_w) // 2
         panel_y = (self.window_height - panel_h) // 2
         
@@ -755,6 +790,22 @@ class ViewPortWindow:
         btn3_x = btn_start_x + (btn_w + btn_gap) * 2
         if btn3_x <= mx <= btn3_x + btn_w and y <= my <= y + btn_h:
             self._refresh_screenshot()
+        
+        # === ACTION BUTTONS ROW 2 (Drag) ===
+        y += btn_h + 12
+        drag_btn_w = btn_w * 2 + btn_gap
+        if btn_start_x <= mx <= btn_start_x + drag_btn_w and y <= my <= y + btn_h:
+            if self.drag_mode_active:
+                # Cancel drag mode
+                self.drag_mode_active = False
+                self.drag_start_point = None
+                self.status_message = "Drag cancelled"
+            else:
+                # Activate drag mode
+                self.drag_mode_active = True
+                self.drag_start_point = None
+                self.status_message = "Click start point on VM"
+                self.show_overlay = False  # Close overlay to allow clicking on VM
         
         # === FINISH BUTTON ===
         y += btn_h + 20
@@ -853,6 +904,14 @@ class ViewPortWindow:
         pg_command = f"pg.scroll({clicks})"
         self._execute_action("scroll", lambda: self.vm.execute_scroll(clicks),
                            pg_command, {"clicks": clicks})
+    
+    def _execute_drag(self, start_x: int, start_y: int, end_x: int, end_y: int):
+        """Execute a drag from start to end coordinates."""
+        pg_command = f"pg.moveTo({start_x}, {start_y}); pg.drag({end_x - start_x}, {end_y - start_y}, duration=0.5)"
+        self._execute_action("drag", 
+                           lambda: self.vm.execute_drag(start_x, start_y, end_x, end_y, duration=0.5),
+                           pg_command, 
+                           {"start_x": start_x, "start_y": start_y, "end_x": end_x, "end_y": end_y})
     
     def _execute_sleep(self, seconds: float):
         """Execute a sleep/wait command."""
@@ -962,7 +1021,7 @@ Actions recorded successfully.
                 elif event.type == pygame.KEYDOWN:
                     if event.key == pygame.K_F12:
                         self._on_finish()
-                    # Handle ESC key with priority: picker -> typing -> overlay -> exit
+                    # Handle ESC key with priority: picker -> typing -> overlay -> drag mode -> exit
                     elif event.key == pygame.K_ESCAPE:
                         if self.picker_active:
                             # Close picker first
@@ -974,6 +1033,11 @@ Actions recorded successfully.
                             # Close overlay
                             self.show_overlay = False
                             self.picker_active = None
+                        elif self.drag_mode_active:
+                            # Cancel drag mode
+                            self.drag_mode_active = False
+                            self.drag_start_point = None
+                            self.status_message = "Drag cancelled"
                         else:
                             # Exit application
                             self.is_running = False
@@ -1001,14 +1065,35 @@ Actions recorded successfully.
                             self._handle_overlay_click(event.pos)
                         elif self._is_on_vm(event.pos) and not self.is_busy:
                             vm_x, vm_y = self._screen_to_vm(event.pos[0], event.pos[1])
-                            self._execute_click(vm_x, vm_y)
+                            # Handle drag mode
+                            if self.drag_mode_active:
+                                if self.drag_start_point is None:
+                                    # First click - set start point
+                                    self.drag_start_point = (vm_x, vm_y)
+                                    self.status_message = f"Start: ({vm_x}, {vm_y}) - Now click end point"
+                                else:
+                                    # Second click - execute drag
+                                    start_x, start_y = self.drag_start_point
+                                    self._execute_drag(start_x, start_y, vm_x, vm_y)
+                                    # Reset drag mode
+                                    self.drag_mode_active = False
+                                    self.drag_start_point = None
+                            else:
+                                # Normal click
+                                self._execute_click(vm_x, vm_y)
                     elif event.button == 3:  # Right click
                         if self._is_on_vm(event.pos) and not self.is_busy and not self.show_overlay:
-                            vm_x, vm_y = self._screen_to_vm(event.pos[0], event.pos[1])
-                            pg_command = f"pg.rightClick({vm_x}, {vm_y})"
-                            self._execute_action("right_click", 
-                                               lambda: self.vm.execute_right_click(vm_x, vm_y),
-                                               pg_command, {"x": vm_x, "y": vm_y})
+                            # Cancel drag mode on right-click
+                            if self.drag_mode_active:
+                                self.drag_mode_active = False
+                                self.drag_start_point = None
+                                self.status_message = "Drag cancelled"
+                            else:
+                                vm_x, vm_y = self._screen_to_vm(event.pos[0], event.pos[1])
+                                pg_command = f"pg.rightClick({vm_x}, {vm_y})"
+                                self._execute_action("right_click", 
+                                                   lambda: self.vm.execute_right_click(vm_x, vm_y),
+                                                   pg_command, {"x": vm_x, "y": vm_y})
             
             # Update viewport panning
             if not self.show_overlay:


### PR DESCRIPTION
- Two-click drag workflow (click start, click end)
- Orange crosshair and visual line indicator in drag mode
- HUD shows drag mode status
- Cancel with ESC, right-click, or Cancel button
- Records pg.moveTo + pg.drag command in trajectory